### PR TITLE
add digest argument to CRL.export

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -392,7 +392,7 @@ class AbstractCa(BaseX509):
             revoked.set_reason(b'unspecified')
             revoked.set_rev_date(bytes_compat(now_str))
             crl.add_revoked(revoked)
-        return crl.export(self.x509, self.pkey, days=1)
+        return crl.export(self.x509, self.pkey, days=1, digest=b'sha256')
 
 
 AbstractCa._meta.get_field('validity_end').default = default_ca_validity_end


### PR DESCRIPTION
pyOpenSSL 17.1 the default digest argument that defaults to md5 was
removed. added digest=b'sha256'