### PR TITLE
set force_insert=False on the second super().save inside BaseX509 (fi…

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -165,6 +165,7 @@ class BaseX509(models.Model):
             if not self.serial_number:
                 self.serial_number = self.id
             self._generate()
+            kwargs['force_insert'] = False
             super(BaseX509, self).save(*args, **kwargs)
 
     @cached_property

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -347,3 +347,14 @@ WRyKPvMvJzWT
         cert._fill_subject(x509.get_subject())
         self.email = 'test@test.com'
         cert._fill_subject(x509.get_subject())
+
+    def test_cert_create(self):
+        ca = Ca(name='Test CA')
+        ca.full_clean()
+        ca.save()
+
+        Cert.objects.create(
+            ca=ca,
+            common_name='TestCert1',
+            name='TestCert1',
+        )


### PR DESCRIPTION
…xes #5)

If using Cert.objects.create() Django uses force_insert=True.

The second call of save() inside baseX509 will fail, because
a PK is created on the first save and it's called again with force_insert=True