### PR TITLE
Temporarily pin cryptography to 2.1.2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 coverage
 coveralls
+cryptography==2.1.2
 isort
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyopenssl>=17.1.0,<17.4.0
 django>=1.10,<1.12
 django-model-utils
 jsonfield
+cryptography==2.1.2


### PR DESCRIPTION
Resolves segmentation faults, see #14 