### PR TITLE
[Fixes #40][Requirements] pyopenssl update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ six
 django>=1.11,<2.1
 django-model-utils
 jsonfield
-cryptography>=2.1.4,<2.3.0
+cryptography>=2.3.0,<2.4.0
 pyopenssl>=17.5.0,<18.1.0


### PR DESCRIPTION
Updated requirement:
cryptography>=2.1.4,<2.4.0, 2.3.1 is the latest & recommended version.

Fixes #40 