### PR TITLE
use self.pk instead of self.id in save method

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -177,7 +177,7 @@ class BaseX509(models.Model):
 
     def save(self, *args, **kwargs):
         generate = False
-        if not self.id and not self.certificate and not self.private_key:
+        if not self.pk and not self.certificate and not self.private_key:
             generate = True
         super(BaseX509, self).save(*args, **kwargs)
         if generate:


### PR DESCRIPTION
Some models don't use an id field.

https://docs.djangoproject.com/en/2.2/ref/models/instances/#django.db.models.Model.pk