### PR TITLE
[ci] Implicitly get coverage version from coveralls

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,2 @@
-coverage
 coveralls
 openwisp-utils[qa]>=0.3.0


### PR DESCRIPTION
The coveralls package already has a dependency on coverage
and sets the boundary according to its support for the coverage library.
We should not duplicate this information.