### PR TITLE
[pki] Add possibility of renewing certificates #83

### DIFF
--- a/django_x509/static/django-x509/css/renew_confirmation.css
+++ b/django_x509/static/django-x509/css/renew_confirmation.css
@@ -1,0 +1,23 @@
+input[type="submit"] {
+    background: #ba2121;
+    border-radius: 4px;
+    padding: 10px 15px;
+    color: #fff;
+}
+a.cancel-link {
+    display: inline-block;
+    vertical-align: middle;
+    height: 15px;
+    line-height: 15px;
+    background: #ddd;
+    border-radius: 4px;
+    padding: 10px 15px;
+    color: #333;
+    margin: 0 0 0 10px;
+}
+a.cancel-link:hover {
+    background-color: #ddd;
+}
+input[type="submit"]:hover {
+    background-color: #ba2121;
+}

--- a/django_x509/templates/admin/django_x509/renew_confirmation.html
+++ b/django_x509/templates/admin/django_x509/renew_confirmation.html
@@ -1,0 +1,65 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n l10n admin_urls static %}
+
+{% block extrahead %}
+<link rel="stylesheet" type="text/css" href="{% static "django-x509/css/renew_confirmation.css" %}" />
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+    <form method="post">
+        {% csrf_token %}
+        <h1>{% trans 'Are You Sure?' %}</h1>
+        {% if ca_count %}
+            {% blocktrans %}
+                <p>Are you sure you want to renew the selected CAs and their related certificates?</p>
+                <p>All the CAs listed below with related certificates will be renewed.</p>
+            {% endblocktrans %}
+        {% else %}
+        {% blocktrans %}
+                <p>Are you sure you want to renew the selected certificates?</p>
+                <p>All the certificates listed below will be renewed.</p>
+            {% endblocktrans %}
+        {% endif %}
+        <h2>{% trans 'Summary:' %}</h2>
+        <ul>
+            {% if ca_count %}
+                <li>{% trans 'CAs:' %} {{ ca_count }}</li>
+            {% endif %}
+            <li>{% trans 'Certificates:' %} {{ cert_count }}</li>
+        </ul>
+        <h2>{% trans 'Objects:' %}</h2>
+        <ul>
+            {% if ca_count %}
+                {% for ca, certs in data.items %}
+                    <li>{% trans 'CA:' %} {{ ca.name }}</li>
+                    <ul>
+                        {% for cert in certs %}
+                            <li>{% trans 'Certificate:' %} {{ cert.name }}</li>
+                        {% endfor %}
+                    </ul>
+                    <input type="hidden" name="_selected_action" value="{{ ca.pk }}">
+                {% endfor %}
+            {% else %}
+                {% for cert in data %}
+                    <li>{% trans 'Certificate:' %} {{ cert.name }}</li>
+                    <input type="hidden" name="_selected_action" value="{{ cert.pk }}">
+                {% endfor %}
+            {% endif %}
+        </ul>
+        <div>
+            <input type="hidden" name="post" value="yes">
+            <input type="submit" value="Yes I'm sure">
+            <input type="hidden" name="action" value="{{ action }}">
+            <a href="{% url 'admin:'|add:cancel_url %}" class="button cancel-link">No, take me back</a>
+        </div>
+    </form>
+{% endblock content %}

--- a/django_x509/tests/test_ca.py
+++ b/django_x509/tests/test_ca.py
@@ -622,3 +622,35 @@ BxZA3knyYRiB0FNYSxI6YuCIqTjr0AoBvNHdkdjkv2VFomYNBd8ruA==
                          generalized_datetime.strftime(generalized_time))
         self.assertEqual(datetime_to_string(utc_datetime),
                          utc_datetime.strftime(utc_time))
+
+    def test_renew(self):
+        ca = self._create_ca()
+        cert1 = self._create_cert(ca=ca, name='cert1')
+        cert2 = self._create_cert(ca=ca, name='cert2')
+        old_ca_cert = ca.certificate
+        old_ca_key = ca.private_key
+        old_ca_end = ca.validity_end
+        old_ca_serial_number = ca.serial_number
+        old_cert1_cert = cert1.certificate
+        old_cert1_key = cert1.private_key
+        old_cert1_serial_number = cert1.serial_number
+        old_cert1_end = cert1.validity_end
+        old_cert2_cert = cert2.certificate
+        old_cert2_key = cert2.private_key
+        old_cert2_serial_number = cert2.serial_number
+        old_cert2_end = cert2.validity_end
+        ca.renew()
+        cert1.refresh_from_db()
+        cert2.refresh_from_db()
+        self.assertNotEqual(old_ca_cert, ca.certificate)
+        self.assertNotEqual(old_ca_key, ca.private_key)
+        self.assertLess(old_ca_end, ca.validity_end)
+        self.assertNotEqual(old_ca_serial_number, ca.serial_number)
+        self.assertNotEqual(old_cert1_cert, cert1.certificate)
+        self.assertNotEqual(old_cert1_key, cert1.private_key)
+        self.assertLess(old_cert1_end, cert1.validity_end)
+        self.assertNotEqual(old_cert1_serial_number, cert1.serial_number)
+        self.assertNotEqual(old_cert2_cert, cert2.certificate)
+        self.assertNotEqual(old_cert2_key, cert2.private_key)
+        self.assertLess(old_cert2_end, cert2.validity_end)
+        self.assertNotEqual(old_cert2_serial_number, cert2.serial_number)

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -488,3 +488,23 @@ BxZA3knyYRiB0FNYSxI6YuCIqTjr0AoBvNHdkdjkv2VFomYNBd8ruA==
         ca.full_clean()
         ca.save()
         self.assertIsInstance(ca.pkey, crypto.PKey)
+
+    def test_renew(self):
+        cert = self._create_cert()
+        old_cert = cert.certificate
+        old_key = cert.private_key
+        old_end = cert.validity_end
+        old_serial_number = cert.serial_number
+        old_ca_cert = cert.ca.certificate
+        old_ca_key = cert.ca.private_key
+        old_ca_end = cert.ca.validity_end
+        old_ca_serial_number = cert.ca.serial_number
+        cert.renew()
+        self.assertNotEqual(old_cert, cert.certificate)
+        self.assertNotEqual(old_key, cert.private_key)
+        self.assertLess(old_end, cert.validity_end)
+        self.assertNotEqual(old_serial_number, cert.serial_number)
+        self.assertEqual(old_ca_cert, cert.ca.certificate)
+        self.assertEqual(old_ca_key, cert.ca.private_key)
+        self.assertEqual(old_ca_end, cert.ca.validity_end)
+        self.assertEqual(old_ca_serial_number, cert.ca.serial_number)


### PR DESCRIPTION
Added a new function in the Ca model which
renews the certificate, private key and
validity end date by calling the generate
function and updating the validity end date.
Also added actions in CA and cert admins to
make use of this newly added function.
Also added a confirmation page to the actions
which Fixes #85

Fixes #83