### PR TITLE
0.8.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ branches:
   only:
     - master
 
-# perform static analysis before installing all dependencies
-# this allows to save resources and build time if this step fails
 before_install:
   - pip install -U pip setuptools wheel
   - pip install --no-cache-dir -U -r requirements-test.txt
@@ -31,13 +29,11 @@ before_install:
 install:
   - pip install $DJANGO
   - python setup.py -q develop
-  - pip install --upgrade https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa]
 
 before_script:
   - ./run-qa-checks
 
 script:
-  - jslint django_x509/static/django-x509/js/*.js
   - coverage run --source=django_x509 runtests.py
   # SAMPLE tests do not influence coverage, so we can speed up tests with --parallel
   - SAMPLE_APP=1 ./runtests.py --parallel --keepdb

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,14 @@
 Changelog
 =========
 
-Version 0.8.0 [unreleased]
+Version 0.8.0 [2020-08-18]
 --------------------------
 
 - Added swapper;
   **breaking change**: systems using django-x509 as a library must set ``DJANGO_X509_CA_MODEL`` & ``DJANGO_X509_CERT_MODEL`` values when upgrading or an exception will be raised
+- Add support for django 0.3.1
+- Add support for cryptography 3.0.0
+- Improved extending django-x509 documentation.
 
 Version 0.7.0 [2020-05-16]
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,26 @@ Changelog
 Version 0.8.0 [2020-08-18]
 --------------------------
 
-- Added swapper;
-  **breaking change**: systems using django-x509 as a library must set ``DJANGO_X509_CA_MODEL`` & ``DJANGO_X509_CERT_MODEL`` values when upgrading or an exception will be raised
-- Add support for django 0.3.1
-- Add support for cryptography 3.0.0
-- Improved extending django-x509 documentation.
+Features
+~~~~~~~~
+
+- Added swappable models, improved extensibility
+- Improved documentation on `how to extend django-x509 <https://github.com/openwisp/django-x509#extending-django-x509>`_
+
+Changes
+~~~~~~~
+
+- **Breaking change**: systems using django-x509 as a library must set ``DJANGO_X509_CA_MODEL``
+  & ``DJANGO_X509_CERT_MODEL`` values in their settings.py when upgrading or an exception like the following one will be raised:
+  
+  ``django.core.exceptions.ImproperlyConfigured: Could not find django_x509.Ca!``
+- Added support for django 3.1
+- Added support for cryptography 3.0.0
+
+Bugfixes
+~~~~~~~~
+
+N/A
 
 Version 0.7.0 [2020-05-16]
 --------------------------

--- a/django_x509/__init__.py
+++ b/django_x509/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0, 'final')
+VERSION = (0, 8, 0, 'final')
 __version__ = VERSION  # alias
 
 

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -2,6 +2,8 @@
 
 set -e
 
+jslint django_x509/static/django-x509/js/*.js
+
 openwisp-qa-check --migrations-to-ignore 4 \
                   --migration-path ./django_x509/migrations/ \
                   --migration-module django_x509


### PR DESCRIPTION
- Added swapper;
  **breaking change**: systems using django-x509 as a library must set ``DJANGO_X509_CA_MODEL`` & ``DJANGO_X509_CERT_MODEL`` values when upgrading or an exception will be raised
- Add support for django 0.3.1
- Add support for cryptography 3.0.0
- Improved extending django-x509 documentation.

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>