### PR TITLE
1.0.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.9.4 [2021-04-14]
   (`issue #113 <https://github.com/openwisp/django-x509/issues/113>`_)
 - [fix] Fixed dependency version definition (minor fix)
 - [deps] Set min cryptography version to 3.4, allow any higher 3.x
+- [deps] Added support for Python ``3.8`` and ``3.9``
 
 Version 0.9.3 [2021-03-16]
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+Version 1.0.0 [2022-02-25]
+--------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fixed `bug in admin <https://github.com/openwisp/django-x509/issues/119>`_
+  for creating CA with blank ``key_length`` and ``digest`` fields
+
+Changes
+~~~~~~~
+
+- Dropped support for Python ``3.6``
+- Added support for Python ``3.8`` and ``3.9``
+- Added support for Django ``3.2.x`` and ``4.0.x``
+- Bumped ``cryptography~=36.0.0``
+- Bumped ``pyopenssl~=21.0.0``
+
 Version 0.9.4 [2021-04-14]
 --------------------------
 

--- a/django_x509/__init__.py
+++ b/django_x509/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 4, 'final')
+VERSION = (1, 0, 0, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
Version 1.0.0 [2022-02-24]
====================

Bugfixes
-----------

- Fixed [bug in admin](https://github.com/openwisp/django-x509/issues/119>) for creating CA with blank ``key_length`` and ``digest``

Dependencies
-------------------

- Dropped support for Python ``3.6``
- Added support for Django ``3.2.x`` and ``4.0.x``
- Bumped ``cryptography~=36.0.0``
- Bumped ``pyopenssl~=21.0.0`