### PR TITLE
[deps] Bumped "openwisp-utils~=1.0.5""

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-# Does not supports Django 4.0.0
+# Does not support Django 4.0.0
 django>=3.2.18,!=4.0.*,<4.3
-openwisp-utils @ https://github.com/openwisp/openwisp-utils/tarball/master
+openwisp-utils~=1.0.5
 jsonfield>=3.1.0,<4.0.0
 cryptography~=42.0.2
 pyOpenSSL~=24.0.0


### PR DESCRIPTION
Missed this in the previous PR, since the breaking package was PyOpenSSL, I did not check that it was also a dependency of openwisp-utils. Apologies for the oversight resulting in multiple PR's.

### Changed

- Bumped "openwisp-utils~=1.0.5".
