### PR TITLE
[fix] Avoid redundant SQL write query during CA/Cert creation generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - django~=4.2.0
           - django~=5.0.0
           - django~=5.1.0
-          - django~=5.2rc0
+          - django~=5.2.0
         exclude:
           # Django 5.0+ requires Python >=3.10
           - python-version: "3.9"
@@ -34,7 +34,7 @@ jobs:
           - python-version: "3.9"
             django-version: django~=5.1.0
           - python-version: "3.9"
-            django-version: django~=5.2rc0
+            django-version: django~=5.2.0
           # Python 3.13 supported only in Django >=5.1.3
           - python-version: "3.13"
             django-version: django~=4.2.0

--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -200,14 +200,11 @@ class BaseX509(models.Model):
         self._verify_extension_format()
 
     def save(self, *args, **kwargs):
-        generate = False
-        if not self.pk and not self.certificate and not self.private_key:
-            generate = True
-            # automatically determine serial number
+        if self._state.adding and not self.certificate and not self.private_key:
+            # auto generate serial number
             if not self.serial_number:
                 self.serial_number = self._generate_serial_number()
             self._generate()
-            
         super().save(*args, **kwargs)
 
     @cached_property

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -4,10 +4,8 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 from OpenSSL import crypto
+from openwisp_utils.tests import AssertNumQueriesSubTestMixin
 from swapper import load_model
-
-# CaptureQueriesContext is a context manager used to capture the number of database queries executed within its block.
-from django.test.utils import CaptureQueriesContext
 
 from .. import settings as app_settings
 from ..base.models import generalized_time
@@ -17,7 +15,7 @@ Ca = load_model('django_x509', 'Ca')
 Cert = load_model('django_x509', 'Cert')
 
 
-class TestCert(TestX509Mixin, TestCase):
+class TestCert(AssertNumQueriesSubTestMixin, TestX509Mixin, TestCase):
     """
     tests for Cert model
     """
@@ -84,24 +82,12 @@ k9Y1S1C9VB0YsDZTeZUggJNSDN4YrKjIevYZQQIhAOWec6vngM/PlI1adrFndd3d
 """
 
     def test_new(self):
-        # Capture queries before optimization
-        #connection argument is a reference to a database connection object (global variable).
-        with CaptureQueriesContext(connection) as queries_before:
-            cert_before =self._create_cert()
-        number_queries_before=len(queries_before)
-        
-        # Capture queries after optimization
-        with CaptureQueriesContext(connection) as queries_after:
+        with self.assertNumQueries(3):
             cert = self._create_cert()
-        number_queries_after=len(queries_after)
-        
-         # Assert that the number of queries has decreased due to the optimization
-        self.assertLess(number_queries_after,number_queries_before)
-        
-        self.assertNotEqual(cert_before.certificate, '')
-        self.assertNotEqual(cert_before.private_key, '')
-        x509 = cert_before.x509
-        self.assertEqual(x509.get_serial_number(), cert_before.serial_number)
+        self.assertNotEqual(cert.certificate, '')
+        self.assertNotEqual(cert.private_key, '')
+        x509 = cert.x509
+        self.assertEqual(x509.get_serial_number(), cert.serial_number)
         subject = x509.get_subject()
         # check subject
         self.assertEqual(subject.countryName, cert.country_code)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #120.

## Description of Changes

Modified a test to the test_new function in test_cert.py to measure the number of database queries before and after the optimization. Ensuring that there should be at least 1 less query.

## Screenshot

![code](https://github.com/user-attachments/assets/9c42cb87-64ab-4332-943d-f6b1c62ae553)

