### PR TITLE
[chores] Ensured serial number stored in DB matches certificate serial number

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -339,6 +339,7 @@ class BaseX509(models.Model):
         digest_alg = HASH_MAP.get(digest_name, hashes.SHA256)()
         cert = builder.sign(signing_key, digest_alg)
         self.certificate = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+        self.serial_number = str(cert.serial_number)
         encryption = (
             serialization.BestAvailableEncryption(self.passphrase.encode("utf-8"))
             if self.passphrase

--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -339,7 +339,6 @@ class BaseX509(models.Model):
         digest_alg = HASH_MAP.get(digest_name, hashes.SHA256)()
         cert = builder.sign(signing_key, digest_alg)
         self.certificate = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-        self.serial_number = str(cert.serial_number)
         encryption = (
             serialization.BestAvailableEncryption(self.passphrase.encode("utf-8"))
             if self.passphrase

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -439,6 +439,15 @@ tsND+97h9r73S+UTOhepQTDB
         x509_obj = cert.x509
         self.assertEqual(x509_obj.serial_number, 3)
 
+    def test_serial_number_db_matches_certificate(self):
+        cert = self._create_cert()
+        cert.refresh_from_db()
+        # The serial number in the X.509 certificate is encoded as a big-endian
+        # hex integer in the DER structure. Convert it to int and verify it
+        # exactly equals the value stored in the database.
+        cert_serial_hex = format(cert.x509.serial_number, "x")
+        self.assertEqual(int(cert_serial_hex, 16), int(cert.serial_number))
+
     def test_bad_serial_number_cert(self):
         try:
             self._create_cert(serial_number="notIntegers")

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -442,9 +442,6 @@ tsND+97h9r73S+UTOhepQTDB
     def test_serial_number_db_matches_certificate(self):
         cert = self._create_cert()
         cert.refresh_from_db()
-        # The serial number in the X.509 certificate is encoded as a big-endian
-        # hex integer in the DER structure. Convert it to int and verify it
-        # exactly equals the value stored in the database.
         cert_serial_hex = format(cert.x509.serial_number, "x")
         self.assertEqual(int(cert_serial_hex, 16), int(cert.serial_number))
 


### PR DESCRIPTION
## Checklist
- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue
Closes #121

## Description of Changes
`_generate()` built the certificate using `int(self.serial_number)` but never read 
the serial number back after signing. The DB value came from `_generate_serial_number()` 
while the certificate value came from what the signing library actually embedded. In the 
pyOpenSSL path set_serial_number() silently truncated 128-bit UUID integers during 
signing, producing two genuinely different integers — exactly what was reported in #121.

Fix: after `cert = builder.sign(...)`, sync the field back:
`self.serial_number = str(cert.serial_number)

Added `test_serial_number_db_matches_certificate` to verify DB and certificate serial 
always match. All 74 existing tests continue to pass.

## Screenshot
N/A 