### PR TITLE
[feature] Added support for custom X.509 extensions via structured ASN.1 DER encoding #222

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -575,7 +575,26 @@ class BaseX509(models.Model):
                     _("Invalid hex string provided for ASN1 value")
                 ) from None
         elif value_kind == "string":
-            payload = raw.encode("utf-8")
+            if asn1_type == "IA5":
+                try:
+                    payload = raw.encode("ascii")
+                except UnicodeEncodeError:
+                    raise ValidationError(
+                        _("IA5String value must contain only ASCII characters")
+                    ) from None
+            elif asn1_type == "PRINTABLE":
+                allowed_printable = set(
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    "abcdefghijklmnopqrstuvwxyz"
+                    "0123456789 '()+,-./:=?"
+                )
+                if not all(ch in allowed_printable for ch in raw):
+                    raise ValidationError(
+                        _("PrintableString contains unsupported characters")
+                    )
+                payload = raw.encode("ascii")
+            else:
+                payload = raw.encode("utf-8")
         else:
             raise ValidationError(
                 _("Unsupported value kind: %s. Use 'hex' or 'string'") % value_kind

--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -86,6 +86,19 @@ def default_digest_algorithm():
     return app_settings.DEFAULT_DIGEST_ALGORITHM
 
 
+def _encode_der_length(length):
+    if length < 0:
+        raise ValueError("Invalid DER length")
+    if length < 128:
+        return bytes([length])
+    length_bytes = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(length_bytes)]) + length_bytes
+
+
+def _encode_der_value(tag, payload):
+    return bytes([tag]) + _encode_der_length(len(payload)) + payload
+
+
 class BaseX509(models.Model):
     """
     Abstract Cert class, shared between Ca and Cert
@@ -516,8 +529,58 @@ class BaseX509(models.Model):
         for ext in self.extensions:
             if not isinstance(ext, dict):
                 raise ValidationError(msg)
-            if not ("name" in ext and "critical" in ext and "value" in ext):
+            has_identifier = "name" in ext or "oid" in ext
+            if not has_identifier:
                 raise ValidationError(msg)
+            if "oid" in ext:
+                if "value" not in ext:
+                    raise ValidationError(msg)
+                try:
+                    x509.ObjectIdentifier(ext["oid"])
+                except (ValueError, TypeError):
+                    raise ValidationError(_("Invalid OID format: %s") % ext["oid"])
+                if "critical" in ext and not isinstance(ext.get("critical"), bool):
+                    raise ValidationError(msg)
+                self._parse_custom_extension_value(ext["value"])
+            elif not ("critical" in ext and "value" in ext):
+                raise ValidationError(msg)
+
+    def _parse_custom_extension_value(self, value):
+        if not isinstance(value, str) or not value:
+            raise ValidationError(_("Custom OID values must be a non-empty string"))
+        if not value.startswith("ASN1:"):
+            raise ValidationError(_("Custom OID values must start with 'ASN1:'"))
+        try:
+            prefix, asn1_type, value_kind, raw = value.split(":", 3)
+        except ValueError:
+            raise ValidationError(
+                _("Invalid ASN1 format. Expected 'ASN1:<TYPE>:<KIND>:<VALUE>'")
+            ) from None
+        asn1_type = asn1_type.strip().upper()
+        value_kind = value_kind.strip().lower()
+        tag_map = {
+            "UTF8": 0x0C,
+            "IA5": 0x16,
+            "PRINTABLE": 0x13,
+            "OCTET": 0x04,
+        }
+        if asn1_type not in tag_map:
+            raise ValidationError(_("Unsupported ASN1 type: %s") % asn1_type)
+        if value_kind == "hex":
+            raw = raw.replace(" ", "").replace(":", "").replace("-", "")
+            try:
+                payload = bytes.fromhex(raw)
+            except ValueError:
+                raise ValidationError(
+                    _("Invalid hex string provided for ASN1 value")
+                ) from None
+        elif value_kind == "string":
+            payload = raw.encode("utf-8")
+        else:
+            raise ValidationError(
+                _("Unsupported value kind: %s. Use 'hex' or 'string'") % value_kind
+            )
+        return _encode_der_value(tag_map[asn1_type], payload)
 
     def _add_extensions(self, builder, public_key):
         """
@@ -582,6 +645,15 @@ class BaseX509(models.Model):
         builder = builder.add_extension(aki, critical=False)
         if self.extensions:
             for ext_data in self.extensions:
+                if "oid" in ext_data:
+                    oid = ext_data.get("oid")
+                    crit = ext_data.get("critical", False)
+                    raw_val = self._parse_custom_extension_value(ext_data.get("value"))
+                    builder = builder.add_extension(
+                        x509.UnrecognizedExtension(x509.ObjectIdentifier(oid), raw_val),
+                        critical=crit,
+                    )
+                    continue
                 name = ext_data.get("name")
                 val = ext_data.get("value", "")
                 crit = ext_data.get("critical", False)

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -317,6 +317,64 @@ tsND+97h9r73S+UTOhepQTDB
         self.assertTrue(e2.critical)
         self.assertIn(x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH, e2.value)
 
+    def test_custom_oid_extensions(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.1",
+                "value": "ASN1:UTF8:string:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                "critical": False,
+            },
+            {
+                "oid": "1.3.6.1.4.1.55555.1.2",
+                "value": "ASN1:UTF8:string:00-B0-D0-63-C2-26",
+                "critical": True,
+            },
+        ]
+        cert = self._create_cert(extensions=extensions)
+        e1 = cert.x509.extensions.get_extension_for_oid(
+            x509.ObjectIdentifier("1.3.6.1.4.1.55555.1.1")
+        )
+        self.assertFalse(e1.critical)
+        self.assertEqual(
+            e1.value.value,
+            b"\x0c$" + b"f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+        )
+        e2 = cert.x509.extensions.get_extension_for_oid(
+            x509.ObjectIdentifier("1.3.6.1.4.1.55555.1.2")
+        )
+        self.assertTrue(e2.critical)
+        self.assertEqual(e2.value.value, b"\x0c\x1100-B0-D0-63-C2-26")
+
+    def test_oid_parser_validation_errors(self):
+        """Test that invalid custom OID formats raise correct ValidationErrors"""
+        invalid_scenarios = [
+            (
+                [{"oid": "1.3.6.1.4.1.55555", "value": "UTF8:string:test"}],
+                "Custom OID values must start with 'ASN1:'",
+            ),
+            (
+                [{"oid": "1.3.6.1.4.1.55555", "value": "ASN1:UTF8:test"}],
+                "Invalid ASN1 format. Expected 'ASN1:<TYPE>:<KIND>:<VALUE>'",
+            ),
+            (
+                [{"oid": "1.3.6.1.4.1.55555", "value": "ASN1:UNKNOWN:string:test"}],
+                "Unsupported ASN1 type: UNKNOWN",
+            ),
+            (
+                [{"oid": "1.3.6.1.4.1.55555", "value": "ASN1:OCTET:hex:zzzzz"}],
+                "Invalid hex string provided for ASN1 value",
+            ),
+            (
+                [{"oid": "not-an-oid", "value": "ASN1:UTF8:string:test"}],
+                "Invalid OID format: not-an-oid",
+            ),
+        ]
+        for extensions, expected_error in invalid_scenarios:
+            with self.subTest(extensions=extensions):
+                with self.assertRaises(ValidationError) as cm:
+                    self._create_cert(extensions=extensions)
+                self.assertIn(expected_error, str(cm.exception))
+
     def test_extensions_error1(self):
         extensions = {}
         try:

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -460,6 +460,71 @@ tsND+97h9r73S+UTOhepQTDB
             "PrintableString contains unsupported characters", str(cm.exception)
         )
 
+    def test_custom_oid_missing_value(self):
+        extensions = [{"oid": "1.3.6.1.4.1.55555.1.7"}]
+        try:
+            self._create_cert(extensions=extensions)
+        except ValidationError as e:
+            msg = e.message_dict.get("__all__", [str(e)])[0]
+            self.assertIn("Extension format invalid", str(msg))
+        else:
+            self.fail("ValidationError not raised")
+
+    def test_custom_oid_invalid_critical_type(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.8",
+                "value": "ASN1:UTF8:string:test",
+                "critical": "yes",
+            }
+        ]
+        try:
+            self._create_cert(extensions=extensions)
+        except ValidationError as e:
+            msg = e.message_dict.get("__all__", [str(e)])[0]
+            self.assertIn("Extension format invalid", str(msg))
+        else:
+            self.fail("ValidationError not raised")
+
+    def test_custom_oid_hex_value(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.9",
+                "value": "ASN1:OCTET:hex:0A:0B:0C",
+            }
+        ]
+        cert = self._create_cert(extensions=extensions)
+        ext = cert.x509.extensions.get_extension_for_oid(
+            x509.ObjectIdentifier("1.3.6.1.4.1.55555.1.9")
+        )
+        self.assertEqual(ext.value.value, b"\x04\x03\x0a\x0b\x0c")
+
+    def test_custom_oid_hex_invalid(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.10",
+                "value": "ASN1:OCTET:hex:0G",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn("Invalid hex string", str(cm.exception))
+
+    def test_custom_oid_long_length(self):
+        long_val = "a" * 128
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.11",
+                "value": f"ASN1:UTF8:string:{long_val}",
+            }
+        ]
+        cert = self._create_cert(extensions=extensions)
+        ext = cert.x509.extensions.get_extension_for_oid(
+            x509.ObjectIdentifier("1.3.6.1.4.1.55555.1.11")
+        )
+        self.assertEqual(ext.value.value[:3], b"\x0c\x81\x80")
+        self.assertEqual(ext.value.value[3:], long_val.encode("utf-8"))
+
     def test_revoke(self):
         cert = self._create_cert()
         self.assertFalse(cert.revoked)

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -403,6 +403,63 @@ tsND+97h9r73S+UTOhepQTDB
         else:
             self.fail("ValidationError not raised")
 
+    def test_custom_oid_invalid_oid(self):
+        extensions = [
+            {
+                "oid": "invalid.oid",
+                "value": "ASN1:UTF8:string:test",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn("Invalid OID", str(cm.exception))
+
+    def test_custom_oid_invalid_asn1_format(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.3",
+                "value": "UTF8:string:test",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn("must start with 'ASN1:'", str(cm.exception))
+
+    def test_custom_oid_invalid_value_kind(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.4",
+                "value": "ASN1:UTF8:blob:test",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn("Unsupported value kind", str(cm.exception))
+
+    def test_custom_oid_invalid_ia5_charset(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.5",
+                "value": "ASN1:IA5:string:cafè",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn("must contain only ASCII characters", str(cm.exception))
+
+    def test_custom_oid_invalid_printable_charset(self):
+        extensions = [
+            {
+                "oid": "1.3.6.1.4.1.55555.1.6",
+                "value": "ASN1:PRINTABLE:string:hello@world",
+            }
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            self._create_cert(extensions=extensions)
+        self.assertIn(
+            "PrintableString contains unsupported characters", str(cm.exception)
+        )
+
     def test_revoke(self):
         cert = self._create_cert()
         self.assertFalse(cert.revoked)

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -329,6 +329,10 @@ tsND+97h9r73S+UTOhepQTDB
                 "value": "ASN1:UTF8:string:00-B0-D0-63-C2-26",
                 "critical": True,
             },
+            {
+                "oid": "1.3.6.1.4.1.55555.1.3",
+                "value": "ASN1:UTF8:string:implicit-critical-false",
+            },
         ]
         cert = self._create_cert(extensions=extensions)
         e1 = cert.x509.extensions.get_extension_for_oid(
@@ -344,6 +348,10 @@ tsND+97h9r73S+UTOhepQTDB
         )
         self.assertTrue(e2.critical)
         self.assertEqual(e2.value.value, b"\x0c\x1100-B0-D0-63-C2-26")
+        e3 = cert.x509.extensions.get_extension_for_oid(
+            x509.ObjectIdentifier("1.3.6.1.4.1.55555.1.3")
+        )
+        self.assertFalse(e3.critical)
 
     def test_oid_parser_validation_errors(self):
         """Test that invalid custom OID formats raise correct ValidationErrors"""


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #222.

## Description of Changes

- Added support for custom Object Identifiers (OIDs) in the `extensions` JSON field.
- Implemented internal helper functions `_encode_der_length` and `_encode_der_value` to wrap custom string/hex values into valid ASN.1 DER bytes.
- Updated `_verify_extension_format` to validate both legacy 'name'-based extensions and new custom 'oid'-based extensions securely.
- Made the 'critical' key optional for custom OID entries while keeping it backward-compatible for legacy fields.
- Added tests for verifying each new functionality.

## Screenshot

<img width="518" height="961" alt="image" src="https://github.com/user-attachments/assets/e326ae00-08f2-4aba-8716-54ba7f743eae" />
