### PR TITLE
[fix] Fixed unsupported x509 extension validation #230

### DIFF
--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime, timedelta
 
@@ -16,6 +17,8 @@ from model_utils.fields import AutoCreatedField, AutoLastModifiedField
 from OpenSSL import crypto
 
 from .. import settings as app_settings
+
+logger = logging.getLogger(__name__)
 
 KEY_LENGTH_CHOICES = (
     ("256", "256 (ECDSA)"),
@@ -200,7 +203,13 @@ class BaseX509(models.Model):
             except ValidationError:
                 raise
             except (TypeError, ValueError) as e:
-                raise ValidationError(str(e)) from e
+                logger.exception("Certificate generation failed")
+                raise ValidationError(
+                    _(
+                        "Certificate generation failed due to invalid "
+                        "certificate parameters."
+                    )
+                ) from e
 
     def full_clean(self, *args, **kwargs):
         """

--- a/django_x509/base/models.py
+++ b/django_x509/base/models.py
@@ -186,12 +186,39 @@ class BaseX509(models.Model):
                 {"key_length": _("Unsupported key length: %s") % self.key_length}
             )
 
-    def save(self, *args, **kwargs):
+    def _generate_if_needed(self):
+        """
+        Generates a new x509 certificate unless already generated.
+        Used during validation and save.
+        """
         if self._state.adding and not self.certificate and not self.private_key:
-            # auto generate serial number
+            # Keep generated material on the instance so save does not repeat it.
             if not self.serial_number:
                 self.serial_number = self._generate_serial_number()
-            self._generate()
+            try:
+                self._generate()
+            except ValidationError:
+                raise
+            except (TypeError, ValueError) as e:
+                raise ValidationError(str(e)) from e
+
+    def full_clean(self, *args, **kwargs):
+        """
+        Generate after Django's standard validation pipeline, not in clean().
+        Generating in clean() would mutate serial_number, certificate and
+        private_key before validate_unique() runs, changing existing validation
+        behavior. Doing it here still turns generation failures into
+        ValidationError instances for forms/admin while preserving the normal
+        validation order.
+        """
+        super().full_clean(*args, **kwargs)
+        self._generate_if_needed()
+
+    def save(self, *args, **kwargs):
+        """
+        Enforces generation of x509 certificate also if validation is skipped.
+        """
+        self._generate_if_needed()
         super().save(*args, **kwargs)
 
     @cached_property

--- a/django_x509/tests/test_ca.py
+++ b/django_x509/tests/test_ca.py
@@ -320,24 +320,54 @@ tsND+97h9r73S+UTOhepQTDB
         else:
             self.fail("ValidationError not raised")
 
-    def test_unsupported_extension_validation_error(self):
-        ca = Ca(
-            name="Test CA",
-            key_length="2048",
-            digest="sha256",
-            country_code="IT",
-            state="RM",
-            city="Rome",
-            organization_name="OpenWISP",
-            email="test@test.com",
-            common_name="openwisp.org",
-            extensions=[
-                {"name": "unsupportedExtension", "critical": False, "value": "test"}
-            ],
-        )
-        with self.assertRaises(ValidationError) as cm:
-            ca.full_clean()
-        self.assertIn("Unsupported extension: unsupportedExtension", str(cm.exception))
+    def test_generation_validation_errors(self):
+        with self.subTest("unsupported extension"):
+            ca = Ca(
+                name="Test CA",
+                key_length="2048",
+                digest="sha256",
+                country_code="IT",
+                state="RM",
+                city="Rome",
+                organization_name="OpenWISP",
+                email="test@test.com",
+                common_name="openwisp.org",
+                extensions=[
+                    {
+                        "name": "unsupportedExtension",
+                        "critical": False,
+                        "value": "test",
+                    }
+                ],
+            )
+            with self.assertRaises(ValidationError) as cm:
+                ca.full_clean()
+            self.assertIn(
+                "Unsupported extension: unsupportedExtension", str(cm.exception)
+            )
+        with self.subTest("unexpected generation error"):
+            ca = Ca(
+                name="Test CA",
+                key_length="2048",
+                digest="sha256",
+                country_code="IT",
+                state="RM",
+                city="Rome",
+                organization_name="OpenWISP",
+                email="test@test.com",
+                common_name="openwisp.org",
+            )
+            with patch.object(Ca, "_generate", side_effect=ValueError("backend error")):
+                with self.assertLogs("django_x509.base.models", level="ERROR") as logs:
+                    with self.assertRaises(ValidationError) as cm:
+                        ca.full_clean()
+            self.assertIn(
+                "Certificate generation failed due to invalid certificate parameters.",
+                str(cm.exception),
+            )
+            self.assertNotIn("backend error", str(cm.exception))
+            self.assertIn("Certificate generation failed", logs.output[0])
+            self.assertIsNotNone(logs.records[0].exc_info)
 
     def test_full_clean_save_generates_once(self):
         ca = Ca(

--- a/django_x509/tests/test_ca.py
+++ b/django_x509/tests/test_ca.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
+from unittest.mock import patch
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -318,6 +319,43 @@ tsND+97h9r73S+UTOhepQTDB
             self.assertIn("Extension format invalid", str(msg))
         else:
             self.fail("ValidationError not raised")
+
+    def test_unsupported_extension_validation_error(self):
+        ca = Ca(
+            name="Test CA",
+            key_length="2048",
+            digest="sha256",
+            country_code="IT",
+            state="RM",
+            city="Rome",
+            organization_name="OpenWISP",
+            email="test@test.com",
+            common_name="openwisp.org",
+            extensions=[
+                {"name": "unsupportedExtension", "critical": False, "value": "test"}
+            ],
+        )
+        with self.assertRaises(ValidationError) as cm:
+            ca.full_clean()
+        self.assertIn("Unsupported extension: unsupportedExtension", str(cm.exception))
+
+    def test_full_clean_save_generates_once(self):
+        ca = Ca(
+            name="Test CA",
+            key_length="2048",
+            digest="sha256",
+            country_code="IT",
+            state="RM",
+            city="Rome",
+            organization_name="OpenWISP",
+            email="test@test.com",
+            common_name="openwisp.org",
+        )
+        with patch.object(Ca, "_generate", wraps=ca._generate) as mocked_generate:
+            ca.full_clean()
+            self.assertEqual(mocked_generate.call_count, 1)
+            ca.save()
+            self.assertEqual(mocked_generate.call_count, 1)
 
     def test_get_revoked_certs(self):
         ca = self._create_ca()

--- a/django_x509/tests/test_cert.py
+++ b/django_x509/tests/test_cert.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
+from unittest.mock import patch
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -336,6 +337,45 @@ tsND+97h9r73S+UTOhepQTDB
             self.assertIn("Extension format invalid", str(msg))
         else:
             self.fail("ValidationError not raised")
+
+    def test_unsupported_extension_validation_error(self):
+        cert = Cert(
+            name="TestCert",
+            ca=self._create_ca(),
+            key_length="2048",
+            digest="sha256",
+            country_code="IT",
+            state="RM",
+            city="Rome",
+            organization_name="Test",
+            email="test@test.com",
+            common_name="openwisp.org",
+            extensions=[
+                {"name": "unsupportedExtension", "critical": False, "value": "test"}
+            ],
+        )
+        with self.assertRaises(ValidationError) as cm:
+            cert.full_clean()
+        self.assertIn("Unsupported extension: unsupportedExtension", str(cm.exception))
+
+    def test_full_clean_save_generates_once(self):
+        cert = Cert(
+            name="TestCert",
+            ca=self._create_ca(),
+            key_length="2048",
+            digest="sha256",
+            country_code="IT",
+            state="RM",
+            city="Rome",
+            organization_name="Test",
+            email="test@test.com",
+            common_name="openwisp.org",
+        )
+        with patch.object(Cert, "_generate", wraps=cert._generate) as mocked_generate:
+            cert.full_clean()
+            self.assertEqual(mocked_generate.call_count, 1)
+            cert.save()
+            self.assertEqual(mocked_generate.call_count, 1)
 
     def test_revoke(self):
         cert = self._create_cert()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #230.

## Description of Changes

This prevents unsupported generated x509 extensions from surfacing as admin server errors.

New generated certificates are built at the end of full_clean(), after Django normal model validation has completed. This keeps generation failures as ValidationError instances for forms and admin while preserving the existing validation order.

The generated certificate and private key remain on the instance, so save() reuses them instead of generating a second certificate.

## Screenshot

Not applicable.